### PR TITLE
Fixed Project Build Settings

### DIFF
--- a/Light Vox Engine/Light Vox Engine.vcxproj
+++ b/Light Vox Engine/Light Vox Engine.vcxproj
@@ -97,10 +97,27 @@
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)_Binary\Assets"
-xcopy "$(SolutionDir)Assets" "$(SolutionDir)_Binary\Assets" /S /Y /E
-</Command>
+      <Command>mkdir "$(SolutionDir)_Binary\Assets\"
+xcopy "$(SolutionDir)Assets\" "$(SolutionDir)_Binary\Assets\" /S /Y /E
+mkdir "$(SolutionDir)_Binary\Assets\Shaders"
+for /r "$(SolutionDir)_Binary" %%x in (*.cso) do move "%%x" "$(SolutionDir)_Binary\Assets\Shaders\"
+
+mkdir "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.ilk) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.pdb) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.iobj) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.ipdb) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>mkdir "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.ilk) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.pdb) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.iobj) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.ipdb) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Moving VS meta data back next to the .exe</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -110,10 +127,27 @@ xcopy "$(SolutionDir)Assets" "$(SolutionDir)_Binary\Assets" /S /Y /E
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)_Binary\Assets"
-xcopy "$(SolutionDir)Assets" "$(SolutionDir)_Binary\Assets" /S /Y /E
-</Command>
+      <Command>mkdir "$(SolutionDir)_Binary\Assets\"
+xcopy "$(SolutionDir)Assets\" "$(SolutionDir)_Binary\Assets\" /S /Y /E
+mkdir "$(SolutionDir)_Binary\Assets\Shaders"
+for /r "$(SolutionDir)_Binary" %%x in (*.cso) do move "%%x" "$(SolutionDir)_Binary\Assets\Shaders\"
+
+mkdir "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.ilk) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.pdb) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.iobj) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.ipdb) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>mkdir "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.ilk) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.pdb) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.iobj) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.ipdb) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Moving VS meta data back next to the .exe</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -129,10 +163,27 @@ xcopy "$(SolutionDir)Assets" "$(SolutionDir)_Binary\Assets" /S /Y /E
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)_Binary\Assets"
-xcopy "$(SolutionDir)Assets" "$(SolutionDir)_Binary\Assets" /S /Y /E
-</Command>
+      <Command>mkdir "$(SolutionDir)_Binary\Assets\"
+xcopy "$(SolutionDir)Assets\" "$(SolutionDir)_Binary\Assets\" /S /Y /E
+mkdir "$(SolutionDir)_Binary\Assets\Shaders"
+for /r "$(SolutionDir)_Binary" %%x in (*.cso) do move "%%x" "$(SolutionDir)_Binary\Assets\Shaders\"
+
+mkdir "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.ilk) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.pdb) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.iobj) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.ipdb) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>mkdir "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.ilk) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.pdb) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.iobj) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.ipdb) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Moving VS meta data back next to the .exe</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -148,10 +199,27 @@ xcopy "$(SolutionDir)Assets" "$(SolutionDir)_Binary\Assets" /S /Y /E
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PostBuildEvent>
-      <Command>mkdir "$(SolutionDir)_Binary\Assets"
-xcopy "$(SolutionDir)Assets" "$(SolutionDir)_Binary\Assets" /S /Y /E
-</Command>
+      <Command>mkdir "$(SolutionDir)_Binary\Assets\"
+xcopy "$(SolutionDir)Assets\" "$(SolutionDir)_Binary\Assets\" /S /Y /E
+mkdir "$(SolutionDir)_Binary\Assets\Shaders"
+for /r "$(SolutionDir)_Binary" %%x in (*.cso) do move "%%x" "$(SolutionDir)_Binary\Assets\Shaders\"
+
+mkdir "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.ilk) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.pdb) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.iobj) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.ipdb) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>mkdir "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.ilk) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.pdb) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.iobj) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"
+for /r "$(SolutionDir)_Binary" %%x in (*.ipdb) do move "%%x" "$(SolutionDir)_Binary\VSMetaData\"</Command>
+    </PreBuildEvent>
+    <PreBuildEvent>
+      <Message>Moving VS meta data back next to the .exe</Message>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />

--- a/Light Vox Engine/Light Vox Engine.vcxproj
+++ b/Light Vox Engine/Light Vox Engine.vcxproj
@@ -71,12 +71,23 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>$(SolutionDir)_Binary\</OutDir>
-    <IntDir>$(SolutionDir)_Binary\$(ProjectName)\$(Configuration)\</IntDir>
-    <TargetName>$(ProjectName) _Debug Build_</TargetName>
+    <IntDir>$(SolutionDir)_Binary\$(PlatformTarget)\$(ProjectName)\$(Configuration)\</IntDir>
+    <TargetName>$(ProjectName) x32_d</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)_Binary\</OutDir>
-    <IntDir>$(SolutionDir)_Binary\$(ProjectName)\$(Configuration)\</IntDir>
+    <IntDir>$(SolutionDir)_Binary\$(PlatformTarget)\$(ProjectName)\$(Configuration)\</IntDir>
+    <TargetName>$(ProjectName) x32</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)_Binary\</OutDir>
+    <IntDir>$(SolutionDir)_Binary\$(PlatformTarget)\$(ProjectName)\$(Configuration)\</IntDir>
+    <TargetName>$(ProjectName) x64_d</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)_Binary\</OutDir>
+    <IntDir>$(SolutionDir)_Binary\$(PlatformTarget)\$(ProjectName)\$(Configuration)\</IntDir>
+    <TargetName>$(ProjectName) x64</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -98,6 +109,11 @@ xcopy "$(SolutionDir)Assets" "$(SolutionDir)_Binary\Assets" /S /Y /E
       <SDLCheck>true</SDLCheck>
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
+    <PostBuildEvent>
+      <Command>mkdir "$(SolutionDir)_Binary\Assets"
+xcopy "$(SolutionDir)Assets" "$(SolutionDir)_Binary\Assets" /S /Y /E
+</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -131,6 +147,11 @@ xcopy "$(SolutionDir)Assets" "$(SolutionDir)_Binary\Assets" /S /Y /E
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
+    <PostBuildEvent>
+      <Command>mkdir "$(SolutionDir)_Binary\Assets"
+xcopy "$(SolutionDir)Assets" "$(SolutionDir)_Binary\Assets" /S /Y /E
+</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />


### PR DESCRIPTION
## Feature/Issue
Build settings didn't support x64, files were a little messy.

## Implementation/Solution
 - Added x64 support
 - Moved compiled shader files to assets folder
 - Moved VS metadata files to a sepearate folder after building (it's moved back next to the .exe prior to building)

## Tests
 - [x] Have you reviewed your own code?
