### PR TITLE
Separate the Entity Components to a separate header

### DIFF
--- a/Light Vox Engine/EntityComponents.h
+++ b/Light Vox Engine/EntityComponents.h
@@ -1,0 +1,124 @@
+#pragma once
+
+/// <summary>
+/// Structures of the different components that an entity can have
+/// </summary>
+/// <author>Arturo</author>
+/// <author>Ben Hoffman</author>
+namespace EntityComponents
+{
+    struct Transform
+    {
+        float position[ 3 ];
+        int body;
+        float rotation[ 4 ];
+    };
+
+    struct BodyProperties
+    {
+        float inertia_inverse[ 3 ];
+        float mass_inverse;
+    };
+
+    struct BodyMomentum
+    {
+        float velocity[ 3 ];
+        float unused0;
+        float angular_velocity[ 3 ];
+        float unused1;
+    };
+
+    struct SphereCollider
+    {
+        float radius;
+    };
+
+    struct BoxCollider
+    {
+        float size[ 3 ];
+        float unused;
+    };
+
+    struct Contact
+    {
+        float position[ 3 ];
+        float penetration;
+        float normal[ 3 ];
+        float friction;
+    };
+
+    struct BodyPair
+    {
+        int a;
+        int b;
+    };
+
+    struct ContactData
+    {
+        Contact* data;
+        BodyPair* bodies;
+        int* tags;
+        int capacity;
+        int count;
+
+        int* sleeping_pairs;
+        int sleeping_count;
+    };
+
+    struct ColliderData
+    {
+        struct
+        {
+            int* tags;
+            BoxCollider* data;
+            Transform* transforms;
+            int count;
+        } boxes;
+
+        struct
+        {
+            int* tags;
+            SphereCollider* data;
+            Transform* transforms;
+            int count;
+        } spheres;
+    };
+
+    struct BodyData
+    {
+        Transform* transforms;
+        BodyProperties* properties;
+        BodyMomentum* momentum;
+        int idle_counters;
+        int count;
+    };
+
+    struct BodyConnections
+    {
+        BodyPair* data;
+        int count;
+    };
+
+    struct CachedContactImpulse
+    {
+        float impulse[ 3 ];
+        float unused;
+    };
+
+    struct ContactCache
+    {
+        int* tags;
+        CachedContactImpulse* data;
+        int capacity;
+        int count;
+    };
+
+    struct ActiveBodies
+    {
+        int* indices;
+        int capacity;
+        int count;
+    };
+
+
+}

--- a/Light Vox Engine/EntityManager.h
+++ b/Light Vox Engine/EntityManager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "EntityComponents.h"
 
 /// <summary>
 /// Singleton for controlling the creation of game entities.
@@ -44,141 +45,24 @@ private:
 
     static EntityManager* Instance;
 
-
-public:
-
     ///////////////////////////////////////////////////
     // Entity components
 
-    struct Transform
-    {
-        float position[ 3 ];
-        int body;
-        float rotation[ 4 ];
-    };
+    // TODO: Make these arrays the proper size
+    EntityComponents::Transform Transforms[ 1024 ];
 
-    struct BodyProperties
-    {
-        float inertia_inverse[ 3 ];
-        float mass_inverse;
-    };
+    EntityComponents::BodyProperties BodyProperties[ 1024 ];
 
-    struct BodyMomentum
-    {
-        float velocity[ 3 ];
-        float unused0;
-        float angular_velocity[ 3 ];
-        float unused1;
-    };
-
-    struct SphereCollider
-    {
-        float radius;
-    };
-
-    struct BoxCollider
-    {
-        float size[ 3 ];
-        float unused;
-    };
-
-    struct Contact
-    {
-        float position[ 3 ];
-        float penetration;
-        float normal[ 3 ];
-        float friction;
-    };
-
-    struct BodyPair
-    {
-        int a;
-        int b;
-    };
-
-    struct ContactData
-    {
-        Contact* data;
-        BodyPair* bodies;
-        int* tags;
-        int capacity;
-        int count;
-
-        int* sleeping_pairs;
-        int sleeping_count;
-    };
-
-    struct ColliderData
-    {
-        struct
-        {
-            int* tags;
-            BoxCollider* data;
-            Transform* transforms;
-            int count;
-        } boxes;
-
-        struct
-        {
-            int* tags;
-            SphereCollider* data;
-            Transform* transforms;
-            int count;
-        } spheres;
-    };
-
-    struct BodyData
-    {
-        Transform* transforms;
-        BodyProperties* properties;
-        BodyMomentum* momentum;
-        int idle_counters;
-        int count;
-    };
-
-    struct BodyConnections
-    {
-        BodyPair* data;
-        int count;
-    };
-
-    struct CachedContactImpulse
-    {
-        float impulse[ 3 ];
-        float unused;
-    };
-
-    struct ContactCache
-    {
-        int* tags;
-        CachedContactImpulse* data;
-        int capacity;
-        int count;
-    };
-
-    struct ActiveBodies
-    {
-        int* indices;
-        int capacity;
-        int count;
-    };
-
+    /*
     struct ContactImpulseData;
     struct ContactConstraintData;
-
     void Collide( ActiveBodies* active_bodies, ContactData* contacts, BodyData bodies, ColliderData colliders, BodyConnections body_connections );
-
     ContactImpulseData* Read_cached_impulses( ContactCache contact_cache, ContactData contacts );
-
     void Write_cached_impulses( ContactCache* contact_cache, ContactData contacts, ContactImpulseData* contact_impulses );
-
     ContactConstraintData* Setup_contact_constraints( ActiveBodies active_bodies, ContactData contacts, BodyData bodies, ContactImpulseData* contact_impulses );
-
     void Apply_Impulses( ContactConstraintData* data, BodyData bodies );
-
     void Update_Cached_impulses( ContactConstraintData* data, ContactImpulseData* contact_impulses );
-
     void UpdatePhysics( ActiveBodies active_bodies, BodyData bodies, float time_step );
-
+    */
 
 };

--- a/Light Vox Engine/Light Vox Engine.vcxproj
+++ b/Light Vox Engine/Light Vox Engine.vcxproj
@@ -236,6 +236,7 @@ for /r "$(SolutionDir)_Binary" %%x in (*.cso) do move "%%x" "$(SolutionDir)_Bina
     <ClInclude Include="d3dx12.h" />
     <ClInclude Include="DXSampleHelper.h" />
     <ClInclude Include="Engine.h" />
+    <ClInclude Include="EntityComponents.h" />
     <ClInclude Include="EntityManager.h" />
     <ClInclude Include="FrameResource.h" />
     <ClInclude Include="GraphicsCore.h" />

--- a/Light Vox Engine/Light Vox Engine.vcxproj.filters
+++ b/Light Vox Engine/Light Vox Engine.vcxproj.filters
@@ -73,6 +73,9 @@
     <ClInclude Include="GameTime.h">
       <Filter>Source Files\Utils</Filter>
     </ClInclude>
+    <ClInclude Include="EntityComponents.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <FxCompile Include="Shaders\ps_basic.hlsl">


### PR DESCRIPTION
Create the Structure of Arrays in entity manager

## Feature/Issue

Separates the Entity Components declarations to their own header, `EntityComponents.h`.

## Implementation/Solution

You can now `#include "EntityComponents.h"` and access their members. Use the `EntityComponents` namespace to access. 

## Tests
 - [X ] Have you reviewed your own code?
