### PR TITLE
Update to job system to support member functions 

### DIFF
--- a/Light Vox Engine/JobSystem/CpuJob.h
+++ b/Light Vox Engine/JobSystem/CpuJob.h
@@ -2,7 +2,6 @@
 
 #include <functional>
 
-
 namespace Jobs
 {
     /// <summary>
@@ -17,8 +16,6 @@ namespace Jobs
         LOW
     };
 
-    typedef void( *CpuJobFuncPtr ) ( void * args, int index );
-    
     /// <summary>
     /// A job that will be run in parallel with others on the CPU
     /// A function pointer for the worker threads to use
@@ -28,14 +25,12 @@ namespace Jobs
     {
         JobPriority priority = JobPriority::NORMAL;
 
-        CpuJobFuncPtr func_ptr = nullptr;
+        std::function<void( void*, int )> job_func;
 
         void* args = nullptr;
 
         int index = 0;
     };
 
-    
-};      // namespace jobs
 
-// This is the definition of a CPU job that we have to roll with
+};      // namespace jobs

--- a/Light Vox Engine/JobSystem/CpuJob.h
+++ b/Light Vox Engine/JobSystem/CpuJob.h
@@ -4,10 +4,14 @@
 
 namespace Jobs
 {
+
+    typedef std::function<void( void*, int )> job_t;
+
     /// <summary>
     /// Priority of a CPU job. Will determine how the job 
     /// is sorted into the job queue
     /// </summary>
+    /// <author>Ben Hoffman</endif>
     enum JobPriority
     {
         CRITICAL,
@@ -23,14 +27,13 @@ namespace Jobs
     /// <author>Ben Hoffman</author>
     struct CpuJob
     {
-        JobPriority priority = JobPriority::NORMAL;
-
-        std::function<void( void*, int )> job_func;
+        job_t job_func;     // This is 64 bytes!!!  Ahhhh
 
         void* args = nullptr;
 
         int index = 0;
-    };
 
+        JobPriority priority = JobPriority::NORMAL;
+    };
 
 };      // namespace jobs

--- a/Light Vox Engine/JobSystem/JobManager.cpp
+++ b/Light Vox Engine/JobSystem/JobManager.cpp
@@ -2,12 +2,6 @@
 
 using namespace Jobs;
 
-void TestBoi()
-{
-    printf( "TEST BOIIII \n" );
-
-}
-
 // Singleton requirement
 JobManager* JobManager::instance = nullptr;
 
@@ -33,7 +27,6 @@ JobManager::JobManager()
 {
     const unsigned int supportedThreads = std::thread::hardware_concurrency();
 
-
     DEBUG_PRINT( "The number of threads supported on this system is: %d\n", supportedThreads );
 
     isDone = false;
@@ -44,16 +37,8 @@ JobManager::JobManager()
         workerThreads.push_back( std::thread( &Jobs::JobManager::WorkerThread, this ) );
     }
 
-    // Ohhhhhh yee
-    AddJob_Generic( std::bind( &TestBoi ) );
+    // AddJob( std::bind( &Jobs::JobManager::TestBoiMember, this, static_cast<void*>("Wait a minute"), 99 ) );
 
-    AddJob_Generic( std::bind( &Jobs::JobManager::TestBoiMember, this ) );
-
-}
-
-void JobManager::TestBoiMember()
-{
-    printf( "\tTEST MEMMMBER\n\n" );
 }
 
 JobManager::~JobManager()
@@ -72,18 +57,6 @@ JobManager::~JobManager()
     printf( "\tJob Manager dtor!\n" );
 }
 
-void Jobs::JobManager::AddJob( std::function<void( void*, int )> aFunc, void* jobArgs )
-{
-    CpuJob tempJob { };
-
-    tempJob.job_func = aFunc;
-    tempJob.args = jobArgs;
-
-    readyQueue.emplace_back( tempJob );
-
-    jobAvailableCondition.notify_one();
-}
-
 void JobManager::WorkerThread()
 {
     std::unique_lock<std::mutex> workerLock( readyQueueMutex );
@@ -97,28 +70,19 @@ void JobManager::WorkerThread()
         if ( isDone ) return;
 
         // If there is a job available, than work on it
-        /*if ( !readyQueue.empty() )
+        if ( !readyQueue.empty() )
         {
             CpuJob CurJob;
             readyQueue.pop_front( CurJob );
-
-            CurJob.job_func( CurJob.args, CurJob.index );
+   
+            CurJob.job_func( CurJob.args, CurJob.index );            
 
             // Notify other threads that a job has been taken and we should probably
             // check to make sure that there isn;t more
             jobAvailableCondition.notify_one();
-        }*/
-
-        if ( !jobQueue.empty() )
-        {
-            job_t curJob;
-            jobQueue.pop_front( curJob );
-            printf( "Inside worky" );
-            curJob();
         }
     }
 }
-
 
 ////////////////////////////////////////
 // Accessors

--- a/Light Vox Engine/JobSystem/JobManager.h
+++ b/Light Vox Engine/JobSystem/JobManager.h
@@ -11,6 +11,8 @@
 
 namespace Jobs
 {
+    typedef std::function<void()> job_t;
+
     /// <summary>
     /// Manage and execute jobs with an aim to increase
     /// efficiency in using a multicore CPU
@@ -37,7 +39,19 @@ namespace Jobs
         /// Add a job without making a cpu job
         /// </summary>
         /// <param name="func_ptr">A function pointer that is considered a job</param>
-        void AddJob( void( *func_ptr )( void* args, int index ), void* jobArgs );
+        //void AddJob( void( *func_ptr )( void* args, int index ), void* jobArgs );
+
+        void AddJob( std::function<void( void*, int )> aFunc, void* jobArgs );
+
+
+
+        template <typename F>
+        void AddJob_Generic( F&& function )
+        {
+            jobQueue.emplace_back( std::forward<F>( function ) );
+
+            jobAvailableCondition.notify_one();
+        }
 
         // TODO: Sequence factory interface
 
@@ -73,6 +87,10 @@ namespace Jobs
         // Ready queue for the jobs
         ConcurrentQueue<CpuJob> readyQueue;
 
+        // Temporary job queue to see if i can get this to work
+        // with member functions
+        ConcurrentQueue<job_t> jobQueue;
+
         /// <summary>
         /// Conditional variable for if a job is available
         /// </summary>
@@ -88,6 +106,7 @@ namespace Jobs
         std::atomic<bool> isDone;
 
 
+        void TestBoiMember();
     };
 
 };      // namespace jobs

--- a/Light Vox Engine/JobSystem/JobSequence.cpp
+++ b/Light Vox Engine/JobSystem/JobSequence.cpp
@@ -24,7 +24,7 @@ UINT JobSequence::Dispatch( void * aJob, void * aArgs, int aJobCount )
 
     CpuJob TheJob { };
     // Cast to a correct type for now
-    TheJob.func_ptr = static_cast<CpuJobFuncPtr> ( aJob );
+    //TheJob.func_ptr = static_cast<CpuJobFuncPtr> ( aJob );
     TheJob.args = aArgs;
 
     sequenceJobs.emplace_front( TheJob );


### PR DESCRIPTION
## Feature/Issue

The first implementation of the job system was naive and didn't support member function pointers, so I have switched it to use `std::function` instead so that it will. 

## Implementation/Solution

A generic `AddJob` function will take in a bound function and put it in the job queue. Here is an example of how you can add a function to the job manager: 

```
Jobs::JobManager::GetInstance()->AddJob( std::bind( &<namespace>::<className>::<function name>, this, <void* params>, <int index> ) );
```


## Tests
 - [X] Have you reviewed your own code?
 - [X] Does it pass unit tests?
