### PR TITLE
Job sys improv

### DIFF
--- a/Light Vox Engine/Engine.cpp
+++ b/Light Vox Engine/Engine.cpp
@@ -303,7 +303,7 @@ void Engine::UsingInputFunc()
     printf( "FPS: %f \n", 1.0f / time->GetDeltaFloatTime() );
 }
 
-inline void Engine::Update()
+void Engine::Update()
 {
     if ( inputManager->IsKeyDown( VK_ESCAPE ) ) // A
         Quit();

--- a/Light Vox Engine/Engine.h
+++ b/Light Vox Engine/Engine.h
@@ -72,7 +72,7 @@ private:
 
     void UsingInputFunc();
 
-    inline void Update();
+    void Update();
 
     /*Debug function to create a console window*/
     void CreateConsoleWindow( int bufferLines, int bufferColumns, int windowLines, int windowColumns );

--- a/Light Vox Engine/JobSystem/JobManager.h
+++ b/Light Vox Engine/JobSystem/JobManager.h
@@ -65,7 +65,7 @@ namespace Jobs
             aJob.jobPtr = jobPtr;
 
             locklessReadyQueue.enqueue( aJob );
-            jobAvailableCondition.notify_one();
+            //jobAvailableCondition.notify_one();
         }
 
         // We don't want anything making copies of this class so delete these operators
@@ -93,16 +93,6 @@ namespace Jobs
         /// them accordingly
         /// </summary>
         void WorkerThread();
-
-        /// <summary>
-        /// A mutex determining if the queue is ready
-        /// </summary>
-        std::mutex readyQueueMutex;
-
-        /// <summary>
-        /// Conditional variable for if a job is available
-        /// </summary>
-        std::condition_variable jobAvailableCondition;
 
         /// <summary>
         /// Worker threads for executing jobs

--- a/Light Vox Engine/JobSystem/JobManager.h
+++ b/Light Vox Engine/JobSystem/JobManager.h
@@ -3,10 +3,8 @@
 #include "../stdafx.h"
 
 #include <thread>               // std::thread
-#include <condition_variable>   // std::condition_variable
 #include <vector>               // std::vector
 #include <atomic>               // std::atomic
-#include <future>               // std::future, std::promise
 
 #include "concurrentqueue.h"    // lock-less queue
 

--- a/Light Vox Engine/Physics/Solver.h
+++ b/Light Vox Engine/Physics/Solver.h
@@ -3,6 +3,7 @@
 /// </summary>
 #pragma once
 #include "../stdafx.h"
+#include <future>               // std::future, std::promise
 #include "../ECS/Entity.h"
 #include "../ECS/ComponentManager.h"
 #include "../JobSystem/JobManager.h"

--- a/Light Vox Engine/Utils/Configs.h
+++ b/Light Vox Engine/Utils/Configs.h
@@ -17,8 +17,8 @@
 // count: 16384  size: 32
 // count: 131072 size: 64
 
-//#define LV_MAX_INSTANCE_COUNT 2048
-//#define LV_MAX_WORLD_SIZE 16
+#define LV_MAX_INSTANCE_COUNT 2048
+#define LV_MAX_WORLD_SIZE 16
 
-#define LV_MAX_INSTANCE_COUNT 1024
-#define LV_MAX_WORLD_SIZE 13
+//#define LV_MAX_INSTANCE_COUNT 1024
+//#define LV_MAX_WORLD_SIZE 13


### PR DESCRIPTION
## Feature/Issue

I removed any mutexs and conditional variables from the job manager. This increased how much of the CPU was being used by _a lot_

## Implementation/Solution

instead of waiting for the an item to be added to the queue, it now just does a `try_pop` and check if it was successful, there there is no contention for a lock. 

## Dependencies (if any?)
 - [ ]
 
## Screenshots/GIF (if applicable)
![image](https://user-images.githubusercontent.com/14983811/49953150-789a6280-fecb-11e8-9a52-d84fcfe32ef0.png)


## Tests
 - [ ] Have you reviewed your own code?
 - [ ] Does it pass unit tests?
